### PR TITLE
Fix "make user_l4v"

### DIFF
--- a/l4v.dockerfile
+++ b/l4v.dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update -q \
 
 # Get l4v and setup isabelle
 RUN mkdir /isabelle \
+    && ln -s /isabelle ~/.isabelle \
     && mkdir -p ~/.isabelle/etc
 
 COPY res/isabelle_settings /root/.isabelle/etc/settings

--- a/user.dockerfile
+++ b/user.dockerfile
@@ -21,6 +21,7 @@ RUN useradd -u ${UID} ${UNAME} \
     && echo 'cd /host' >> /home/${UNAME}/.bashrc \
     && mkdir -p /isabelle \
     && chown -R ${UNAME}:${UNAME} /isabelle \
+    && ln -s /isabelle /home/${UNAME}/.isabelle \
     && chown -R ${UNAME}:${UNAME} /home/${UNAME} \
     && chmod -R ug+rw /home/${UNAME} 
 


### PR DESCRIPTION
Recent commits have led the user_l4v account to be configured with an empty .isabelle dir. 
This pull request restores the way things worked previously, by letting root and user_l4v share the same .isabelle dir: both shall be symlinks to  the /isabelle dir.