### PR TITLE
Let users be sudoers

### DIFF
--- a/user.dockerfile
+++ b/user.dockerfile
@@ -7,6 +7,8 @@ ARG UNAME
 
 # Crammed a lot in here to make building the image faster
 RUN useradd -u ${UID} ${UNAME} \
+    && adduser ${UNAME} sudo \
+    && passwd -d ${UNAME} \
     && mkdir /home/${UNAME} \
     && echo 'echo "___                                   "' >> /home/${UNAME}/.bashrc \
     && echo 'echo " |   _      _ |_      _   _ |_ |_     "' >> /home/${UNAME}/.bashrc \


### PR DESCRIPTION
To let  users use additional tools, the way to go is to add lines in extras.dockerfile.
Nevertheless, the process of discovering the tools you need, then terminate the user container, add lines to extras.dockerfile, build a new image and run a new container is very tedious - especially doing that one tool at a time, which is what happens in practice.
So I suggest to let users be sudoers, in order to let them install new tools while using a container, then report them to extras.dockerfile for later use.
To sum up, it's a suggested usability improvement.