### PR TITLE
Make the verification for old images less severe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -291,10 +291,10 @@ ifeq ($(shell id -u),0)
 endif
 
 	# Figure out if any trustworthy systems docker images are potentially too old
-	@for img in $(shell docker images --filter=reference='trustworthysystems/*' -q); do \
+	@for img in $(shell docker images --filter=reference='trustworthysystems/*:latest' -q); do \
 		if [ $$(( ( $$(date +%s) - $$(date --date=$$(docker inspect --format='{{.Created}}' $${img}) +%s) ) / (60*60*24) )) -gt 30 ]; then \
 			echo "The docker image: $$(docker inspect --format='{{(index .RepoTags 0)}}' $${img}) is getting a bit old (more than 30 days). You should consider updating it."; \
-			sleep 10; \
+			sleep 2; \
 		fi; \
 	done;
 


### PR DESCRIPTION
I suggest only trustworthy/*:latest images be checked for freshness.
Indeed, when one pulls fresh trustworthy images, some previous versions may be usefully kept (e.g. because they're used by a running container or for any reason one should want to keep a previous version for reference).
Also, I suggest the sleep time be reduced, 2 seconds are long enough to read the message and acknowledge it.