### PR TITLE
Make the CAmkES Docker images work under `podman`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ user_run_l4v:
 		-u $(shell id -u):$(shell id -g) \
 		-v $(HOST_DIR):/host:z \
 		-v $(DOCKER_VOLUME_HOME):/home/$(shell whoami) \
-		-v $(DOCKER_VOLUME_ISABELLE):/isabelle \
+		-v $(DOCKER_VOLUME_ISABELLE):/isabelle:exec \
 		-v /etc/localtime:/etc/localtime:ro \
 		-v /tmp/.X11-unix:/tmp/.X11-unix \
 		-e DISPLAY=$(DISPLAY) \

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ user_run:
 		--hostname in-container \
 		--rm \
 		-u $(shell id -u):$(shell id -g) \
-		-v $(HOST_DIR):/host \
+		-v $(HOST_DIR):/host:z \
 		-v $(DOCKER_VOLUME_HOME):/home/$(shell whoami) \
 		-v /etc/localtime:/etc/localtime:ro \
 		$(USER_IMG) $(EXEC)
@@ -127,7 +127,7 @@ user_run_l4v:
 		--hostname in-container \
 		--rm \
 		-u $(shell id -u):$(shell id -g) \
-		-v $(HOST_DIR):/host \
+		-v $(HOST_DIR):/host:z \
 		-v $(DOCKER_VOLUME_HOME):/home/$(shell whoami) \
 		-v $(DOCKER_VOLUME_ISABELLE):/isabelle \
 		-v /etc/localtime:/etc/localtime:ro \

--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ endif
 
 	# Figure out if any trustworthy systems docker images are potentially too old
 	@for img in $(shell docker images --filter=reference='trustworthysystems/*:latest' -q); do \
-		if [ $$(( ( $$(date +%s) - $$(date --date=$$(docker inspect --format='{{.Created}}' $${img}) +%s) ) / (60*60*24) )) -gt 30 ]; then \
+		if [ $$(( ( $$(date +%s) - $$(date --date=$$(docker inspect --format='{{json .Created}}' $${img} | tr -d '"') +%s) ) / (60*60*24) )) -gt 30 ]; then \
 			echo "The docker image: $$(docker inspect --format='{{(index .RepoTags 0)}}' $${img}) is getting a bit old (more than 30 days). You should consider updating it."; \
 			sleep 2; \
 		fi; \

--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,8 @@ build_user: run_checks
 		--build-arg=EXTRAS_IMG=$(EXTRAS_IMG) \
 		--build-arg=UNAME=$(shell whoami) \
 		--build-arg=UID=$(shell id -u) \
+		--build-arg=GID=$(shell id -g) \
+		--build-arg=GROUP=$(shell id -gn) \
 		-f dockerfiles/user.dockerfile \
 		-t $(USER_IMG) .
 build_user_sel4: USER_BASE_IMG = $(SEL4_IMG)

--- a/dockerfiles/user.dockerfile
+++ b/dockerfiles/user.dockerfile
@@ -4,9 +4,12 @@ FROM $EXTRAS_IMG
 # Get user UID and username
 ARG UID
 ARG UNAME
+ARG GID
+ARG GROUP
 
 # Crammed a lot in here to make building the image faster
-RUN useradd -u ${UID} ${UNAME} \
+RUN groupadd -g ${GID} ${GROUP} \
+    && useradd -u ${UID} -g ${GID} ${UNAME} \
     && adduser ${UNAME} sudo \
     && passwd -d ${UNAME} \
     && echo 'Defaults        lecture_file = /etc/sudoers.lecture' >> /etc/sudoers \
@@ -33,9 +36,9 @@ RUN useradd -u ${UID} ${UNAME} \
     && echo 'export PATH=/scripts/repo:$PATH' >> /home/${UNAME}/.bashrc \
     && echo 'cd /host' >> /home/${UNAME}/.bashrc \
     && mkdir -p /isabelle \
-    && chown -R ${UNAME}:${UNAME} /isabelle \
+    && chown -R ${UNAME}:${GROUP} /isabelle \
     && ln -s /isabelle /home/${UNAME}/.isabelle \
-    && chown -R ${UNAME}:${UNAME} /home/${UNAME} \
+    && chown -R ${UNAME}:${GROUP} /home/${UNAME} \
     && chmod -R ug+rw /home/${UNAME} 
 
 VOLUME /home/${UNAME}


### PR DESCRIPTION
This changeset makes it possible to run the `Makefile` when on a system
where `docker` is actually `podman`. It ensures that host mounts are given
sensible container labels for SELinux with the `:z` option, and avoids using
the in-container dev user in favour of believing that root is actually isolated
by the container runtime.