### PR TITLE
Fix rust script, so any user can use the rust compiler.

### DIFF
--- a/dockerfiles/apply-rust.Dockerfile
+++ b/dockerfiles/apply-rust.Dockerfile
@@ -10,6 +10,7 @@ ARG SCM
 ARG DESKTOP_MACHINE=no
 ARG INTERNAL=no
 ARG MAKE_CACHES=yes
+ARG CARGO_HOME="/etc/cargo"
 
 ARG SCRIPT=apply-rust.sh
 
@@ -20,9 +21,5 @@ RUN /bin/bash /tmp/${SCRIPT} \
     && apt-get autoremove --purge --yes \
     && rm -rf /var/lib/apt/lists/*
 
-# Docker doesn't know the HOME variable at this level, so we have to set it by
-# hand here. I don't like it, but it works for now. We currently build as `root`
-# so this should work fine.
-ARG HOME="/root"
-# Doubley make sure that the PATH is set right
-ENV PATH "${PATH}:${HOME}/.cargo/bin"
+ENV PATH "${PATH}:${CARGO_HOME}/bin"
+ENV CARGO_HOME "$CARGO_HOME"

--- a/scripts/apply-rust.sh
+++ b/scripts/apply-rust.sh
@@ -10,6 +10,7 @@ test -d "$DIR" || DIR=$PWD
 
 # tmp space for building 
 : "${TEMP_DIR:=/tmp}"
+: "${CARGO_HOME:=/etc/cargo}"
 
 # Not strictly necessary, but it makes the apt operations in
 # ../dockerfiles/apply-rust.dockerfile work.
@@ -18,11 +19,22 @@ as_root apt-get update -q
 try_nonroot_first mkdir -p "$TEMP_DIR" || chown_dir_to_user "$TEMP_DIR"
 # Get rust nightly
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > "$TEMP_DIR/rustup.sh"
+
+try_nonroot_first mkdir -p "$CARGO_HOME" || chown_dir_to_user "$CARGO_HOME"
+
 sh "$TEMP_DIR/rustup.sh" -y --default-toolchain nightly
 rm "$TEMP_DIR/rustup.sh"
 
+# Update the current shell
+# shellcheck disable=SC1090
+source "$CARGO_HOME"/env
+
 # Install rumprun target
-"$HOME/.cargo/bin/rustup" target add x86_64-rumprun-netbsd
+rustup target add x86_64-rumprun-netbsd
+
+# Make sure that all the files are accessible to other users:
+try_nonroot_first chmod -R o+rx "$CARGO_HOME"
 
 # Add cargo and rust to PATH
-echo "export PATH=\"\$PATH:\$HOME/.cargo/bin\"" >> "$HOME/.bashrc"
+echo "export CARGO_HOME=\"$CARGO_HOME\"" >> "$HOME/.bashrc"
+echo "export PATH=\"\$PATH:\$CARGO_HOME/bin\"" >> "$HOME/.bashrc"


### PR DESCRIPTION
Fix for the issue raised here: https://sel4.systems/pipermail/devel/2020-August/002851.html

Essentially, the rust compiler was being put in a place that only the `root` user could access, which is not very useful.

This puts it in a generic place, and ensures the permissions are OK.

This PR should not be merged on GitHub, it should be merged internally first.