### PR TITLE
upgrade tools to build core platform sdk

### DIFF
--- a/dockerfiles/extras.Dockerfile
+++ b/dockerfiles/extras.Dockerfile
@@ -4,7 +4,8 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-ARG USER_BASE_IMG=trustworthysystems/sel4
+# ARG USER_BASE_IMG=trustworthysystems/sel4 # original base image
+ARG USER_BASE_IMG
 # hadolint ignore=DL3006
 FROM $USER_BASE_IMG
 

--- a/dockerfiles/sel4cp.Dockerfile
+++ b/dockerfiles/sel4cp.Dockerfile
@@ -79,4 +79,3 @@ RUN echo "export PATH=${MUSL_DIR}/${MUSL_ARCH}/bin:\$PATH\n" >> /root/.bashrc
 #
 
 COPY scripts/utils/cp_prep.sh /tmp/
-

--- a/dockerfiles/sel4cp.Dockerfile
+++ b/dockerfiles/sel4cp.Dockerfile
@@ -80,6 +80,3 @@ RUN echo "export PATH=${MUSL_DIR}/${MUSL_ARCH}/bin:\$PATH\n" >> /root/.bashrc
 
 COPY scripts/utils/cp_prep.sh /tmp/
 
-
-
-

--- a/dockerfiles/sel4cp.Dockerfile
+++ b/dockerfiles/sel4cp.Dockerfile
@@ -1,0 +1,85 @@
+#
+# Copyright 2021, Nataliya Korovkina, malus.brandywine@gmail.com
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+ARG USER_BASE_IMG=trustworthysystems/sel4
+FROM $USER_BASE_IMG
+
+#
+# Take care of python3 version & other missing packages
+#
+
+RUN apt update
+RUN apt-get -y install python3.9 python3.9-venv
+RUN apt-get -y install pandoc texlive-latex-base texlive-latex-extra
+RUN apt-get -y install rsync
+
+
+#
+# Take care of cross compilation tools, version 10.2-2020.11
+#
+
+ARG TMP_DIR=/tmp/gcc-x86_64-aarch64-none-elf
+
+# destination directory for the tools' binaries
+ARG GCC_BIN_DIR=/usr/local/gcc-x86_64-aarch64-none-elf
+
+ARG GCC_PREBUILT_TGZ=gcc-arm-10.2-2020.11-x86_64-aarch64-none-elf.tar.xz
+ARG GCC_PREBUILT_TGZ_URL="https://developer.arm.com/-/media/Files/downloads/gnu-a/10.2-2020.11/binrel/gcc-arm-10.2-2020.11-x86_64-aarch64-none-elf.tar.xz?revision=79f65c42-1a1b-43f2-acb7-a795c8427085&hash=61BBFB526E785D234C5D8718D9BA8E61"
+
+ARG GCC_PREBUILT_ASC=gcc-arm-10.2-2020.11-x86_64-aarch64-none-elf.tar.xz.asc
+ARG GCC_PREBUILT_ASC_URL="https://developer.arm.com/-/media/Files/downloads/gnu-a/10.2-2020.11/binrel/gcc-arm-10.2-2020.11-x86_64-aarch64-none-elf.tar.xz.asc?revision=99909d67-54df-42bb-ae0e-bff40ffdc8ea&hash=FF86380F05240E4994917727CD7D3C2D"
+
+# The directory name the archive will be exctracted to
+ARG GCC_BIN_DIR_VERSIONED=gcc-arm-10.2-2020.11-x86_64-aarch64-none-elf
+
+RUN mkdir ${TMP_DIR}
+RUN mkdir ${GCC_BIN_DIR}
+
+RUN wget -nv --tries=10 -O ${TMP_DIR}/${GCC_PREBUILT_TGZ} ${GCC_PREBUILT_TGZ_URL}
+RUN wget -nv --tries=10 -O ${TMP_DIR}/${GCC_PREBUILT_ASC} ${GCC_PREBUILT_ASC_URL}
+
+RUN tar -xJf ${TMP_DIR}/${GCC_PREBUILT_TGZ} -C ${TMP_DIR}
+
+RUN cd ${TMP_DIR}; md5sum --check ${GCC_PREBUILT_ASC}
+
+RUN rsync -a ${TMP_DIR}/${GCC_BIN_DIR_VERSIONED}/  ${GCC_BIN_DIR}/
+
+RUN echo "export PATH=${GCC_BIN_DIR}/bin:\$PATH\n" >> /root/.bashrc
+
+
+#
+# Take care of musl library, we take the latest one
+#
+
+ARG MUSL_DIR=/usr/local/musl
+ARG MUSL_ARCH=aarch64
+ARG MUSL_GIT_DIR="git://git.musl-libc.org/musl"
+ARG MUSL_BUILD_DIR=/tmp/musl.build
+
+
+RUN mkdir ${MUSL_BUILD_DIR}
+RUN git clone ${MUSL_GIT_DIR} ${MUSL_BUILD_DIR}
+
+RUN . ~/.bashrc; cd ${MUSL_BUILD_DIR}; \
+    ./configure  \
+--prefix=${MUSL_DIR}/${MUSL_ARCH} --enable-wrapper=gcc
+
+RUN . ~/.bashrc; make -C ${MUSL_BUILD_DIR}
+RUN . ~/.bashrc; make -C ${MUSL_BUILD_DIR} install
+
+
+RUN echo "export PATH=${MUSL_DIR}/${MUSL_ARCH}/bin:\$PATH\n" >> /root/.bashrc
+
+#
+# Copy shell script cp_init.sh to get proper project sources
+# and build local python environment
+#
+
+COPY scripts/utils/cp_prep.sh /tmp/
+
+
+
+

--- a/scripts/utils/cp_prep.sh
+++ b/scripts/utils/cp_prep.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+#
+# Copyright 2021, Nataliya Korovkina, malus.brandywine@gmail.com
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+
+SDK_DIR=/host/sel4-core-platform
+
+SEL4_URL="https://github.com/BreakawayConsulting/seL4.git"
+SEL4_BRANCH_NAME="sel4cp-core-support"
+SEL4_SRC_DIR=${SDK_DIR}/sel4_cp_support
+
+CP_URL="https://github.com/BreakawayConsulting/sel4cp.git"
+CP_BRANCH_NAME=""
+CP_DIR=${SDK_DIR}/sel4cp
+
+
+mkdir -p ${SEL4_SRC_DIR} ;mkdir -p ${CP_DIR}
+
+# Getting proper seL4
+git clone -b ${SEL4_BRANCH_NAME} ${SEL4_URL} ${SEL4_SRC_DIR}
+
+# Getting core platform source
+git clone ${CP_URL} ${CP_DIR}
+
+# Local python env
+cd ${SDK_DIR}; python3.9 -m venv pyenv; \
+        ./pyenv/bin/pip install --upgrade pip setuptools wheel; \
+        ./pyenv/bin/pip install sel4-deps; \
+        ./pyenv/bin/pip install -r ${CP_DIR}/requirements.txt
+

--- a/scripts/utils/cp_prep.sh
+++ b/scripts/utils/cp_prep.sh
@@ -30,4 +30,3 @@ cd ${SDK_DIR}; python3.9 -m venv pyenv; \
         ./pyenv/bin/pip install --upgrade pip setuptools wheel; \
         ./pyenv/bin/pip install sel4-deps; \
         ./pyenv/bin/pip install -r ${CP_DIR}/requirements.txt
-


### PR DESCRIPTION
New intermediate image was added between "TS/sel4" image and "extras".

The sel4cp.dockerfile:
updates python packages, adds other necessary packages,
installs ARM cross-tools binaries 10.2-2020.11,
clones and builds the latest musl,
copies script cp_prep.sh into /tmp

Signed-off-by: Nataliya Korovkina <malus.brandywine@gmail.com>