### PR TITLE
Update docker containers to use Debian Trixie as basis 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ DOCKER ?= docker
 DOCKERHUB ?= trustworthysystems/
 
 # Base images
-DEBIAN_IMG ?= debian:bullseye-slim
+DEBIAN_IMG ?= debian:trixie-slim
 BASETOOLS_IMG ?= base_tools
 
 # Core images

--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,7 @@ set -ef
 : "${DOCKERHUB:=trustworthysystems/}"
 
 # Base images
-: "${DEBIAN_IMG:=debian:bullseye-slim}"
+: "${DEBIAN_IMG:=debian:trixie-slim}"
 : "${BASETOOLS_IMG:=base_tools}"
 
 # Core images

--- a/dockerfiles/apply-cakeml.Dockerfile
+++ b/dockerfiles/apply-cakeml.Dockerfile
@@ -29,4 +29,4 @@ COPY --from=builder ${CAKEML32_BIN_DIR} ${CAKEML32_BIN_DIR}
 COPY --from=builder ${CAKEML64_BIN_DIR} ${CAKEML64_BIN_DIR}
 COPY --from=builder ${CAKEML_DIR} ${CAKEML_DIR}
 
-ENV PATH "${PATH}:${HOL_DIR}/bin"
+ENV PATH="${PATH}:${HOL_DIR}/bin"

--- a/dockerfiles/apply-rust.Dockerfile
+++ b/dockerfiles/apply-rust.Dockerfile
@@ -27,5 +27,5 @@ RUN /bin/bash /tmp/${SCRIPT} \
     && apt-get autoremove --purge --yes \
     && rm -rf /var/lib/apt/lists/*
 
-ENV PATH "${PATH}:${CARGO_HOME}/bin"
-ENV CARGO_HOME "$CARGO_HOME"
+ENV PATH="${PATH}:${CARGO_HOME}/bin"
+ENV CARGO_HOME="$CARGO_HOME"

--- a/dockerfiles/apply-sysinit.Dockerfile
+++ b/dockerfiles/apply-sysinit.Dockerfile
@@ -28,4 +28,4 @@ COPY --from=builder ${CAKEML32_BIN_DIR} ${CAKEML32_BIN_DIR}
 COPY --from=builder ${CAKEML64_BIN_DIR} ${CAKEML64_BIN_DIR}
 COPY --from=builder ${CAKEML_DIR} ${CAKEML_DIR}
 
-ENV PATH "${PATH}:${HOL_DIR}/bin"
+ENV PATH="${PATH}:${HOL_DIR}/bin"

--- a/dockerfiles/base_tools.Dockerfile
+++ b/dockerfiles/base_tools.Dockerfile
@@ -34,4 +34,4 @@ RUN echo ipv4 >> ~/.curlrc \
     && rm -rf /var/lib/apt/lists/*
 
 # ENV variables are available to containers after the build stage
-ENV PATH "${PATH}:${REPO_DIR}"
+ENV PATH="${PATH}:${REPO_DIR}"

--- a/dockerfiles/base_tools.Dockerfile
+++ b/dockerfiles/base_tools.Dockerfile
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-ARG BASE_IMG=debian:bullseye-slim
+ARG BASE_IMG=debian:trixie-slim
 # hadolint ignore=DL3006
 FROM $BASE_IMG
 ARG TARGETPLATFORM

--- a/dockerfiles/cakeml.Dockerfile
+++ b/dockerfiles/cakeml.Dockerfile
@@ -34,4 +34,4 @@ RUN /bin/bash /tmp/${SCRIPT} \
     && rm -rf /var/lib/apt/lists/*
 
 # Doubley make sure that the PATH is set right
-ENV PATH "${PATH}:${HOL_DIR}/bin"
+ENV PATH="${PATH}:${HOL_DIR}/bin"

--- a/dockerfiles/l4v.Dockerfile
+++ b/dockerfiles/l4v.Dockerfile
@@ -14,7 +14,7 @@ LABEL MAINTAINER="Luke Mondy (luke.mondy@data61.csiro.au)"
 ##########################################################
 # Do some setup to prepare for the shell script to be run
 COPY res/isabelle_settings /tmp
-ENV NEW_ISABELLE_SETTINGS "/tmp/isabelle_settings"
+ENV NEW_ISABELLE_SETTINGS="/tmp/isabelle_settings"
 ##########################################################
 
 # ARGS are env vars that are *only available* during the docker build

--- a/dockerfiles/sel4.Dockerfile
+++ b/dockerfiles/sel4.Dockerfile
@@ -27,4 +27,4 @@ RUN /bin/bash /tmp/${SCRIPT} \
     && apt-get autoremove --purge --yes \
     && rm -rf /var/lib/apt/lists/*
 
-ENV LANG en_AU.UTF-8
+ENV LANG=en_AU.UTF-8

--- a/dockerfiles/sysinit.Dockerfile
+++ b/dockerfiles/sysinit.Dockerfile
@@ -38,4 +38,4 @@ RUN /bin/bash /tmp/${SCRIPT} \
     && rm -rf /var/lib/apt/lists/*
 
 # Doubley make sure that the PATH is set right
-ENV PATH "${PATH}:${HOL_DIR}/bin"
+ENV PATH="${PATH}:${HOL_DIR}/bin"

--- a/scripts/apply-camkes_vis.sh
+++ b/scripts/apply-camkes_vis.sh
@@ -25,7 +25,7 @@ as_root apt-get install -y --no-install-recommends \
         xvfb \
         # end of list
 
-as_root pip3 install --no-cache-dir \
+as_root pip3 install --break-system-packages --no-cache-dir \
     ansi2html \
     graphviz \
     pydotplus \

--- a/scripts/apply-polyml.sh
+++ b/scripts/apply-polyml.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Copyright 2025, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+# Install PolyML from GitHub source
+
+set -exuo pipefail
+
+version="5.9.2"
+url="https://github.com/polyml/polyml/archive/refs/tags/v${version}.tar.gz"
+TMP_DIR="/tmp"
+
+wget -4 "${url}" --directory-prefix="$TMP_DIR"
+
+pushd "$TMP_DIR"
+tar -xzf "v${version}.tar.gz"
+pushd "polyml-${version}"
+./configure --prefix=/usr
+make
+make install
+rm -rf "v${version}.tar.gz" "polyml-${version}"
+popd
+popd

--- a/scripts/base_tools.sh
+++ b/scripts/base_tools.sh
@@ -33,12 +33,12 @@ if [ "$DESKTOP_MACHINE" = "no" ] ; then
     # We need to start with a fresh sources.list, to put in both the regular
     # sources, and the snapshot ones
     as_root tee /etc/apt/sources.list << EOF
-# deb http://snapshot.debian.org/archive/debian/$SNAPSHOT_DATE/ bullseye main
-deb http://deb.debian.org/debian bullseye main
-# deb http://snapshot.debian.org/archive/debian-security/$SNAPSHOT_DATE/ bullseye-security main
-deb http://security.debian.org/debian-security bullseye-security main
-# deb http://snapshot.debian.org/archive/debian/$SNAPSHOT_DATE/ bullseye-updates main
-deb http://deb.debian.org/debian bullseye-updates main
+# deb http://snapshot.debian.org/archive/debian/$SNAPSHOT_DATE/ trixie main
+deb http://deb.debian.org/debian trixie main
+# deb http://snapshot.debian.org/archive/debian-security/$SNAPSHOT_DATE/ trixie-security main
+deb http://security.debian.org/debian-security trixie-security main
+# deb http://snapshot.debian.org/archive/debian/$SNAPSHOT_DATE/ trixie-updates main
+deb http://deb.debian.org/debian trixie-updates main
 EOF
 
     # Snapshot has some rate limiting, so avoid its ire

--- a/scripts/base_tools.sh
+++ b/scripts/base_tools.sh
@@ -32,6 +32,8 @@ if [ "$DESKTOP_MACHINE" = "no" ] ; then
 
     # We need to start with a fresh sources.list, to put in both the regular
     # sources, and the snapshot ones
+    as_root rm -f /etc/apt/sources.list.d/debian.sources
+
     as_root tee /etc/apt/sources.list << EOF
 # deb http://snapshot.debian.org/archive/debian/$SNAPSHOT_DATE/ trixie main
 deb http://deb.debian.org/debian trixie main

--- a/scripts/base_tools.sh
+++ b/scripts/base_tools.sh
@@ -88,9 +88,9 @@ as_root apt-get install -y --no-install-recommends \
 # Install python dependencies
 # Upgrade pip first, then install setuptools (required for other pip packages)
 # Install some basic python tools
-as_root pip3 install --no-cache-dir \
+as_root pip3 install --break-system-packages --no-cache-dir \
     setuptools
-as_root pip3 install --no-cache-dir \
+as_root pip3 install --break-system-packages --no-cache-dir \
     gitlint \
     nose \
     reuse \

--- a/scripts/camkes.sh
+++ b/scripts/camkes.sh
@@ -38,7 +38,7 @@ as_root dpkg --add-architecture i386
 as_root dpkg --add-architecture arm64
 as_root apt-get update -q
 
-# lib32stdc++-10-dev for 32-bit Linux VMM
+# lib32stdc++-14-dev for 32-bit Linux VMM
 as_root apt-get install -y --no-install-recommends \
     acl \
     fakeroot \
@@ -46,7 +46,7 @@ as_root apt-get install -y --no-install-recommends \
     linux-libc-dev:i386 \
     pkg-config \
     spin \
-    lib32stdc++-10-dev:amd64 \
+    lib32stdc++-14-dev:amd64 \
     # end of list
 
 # Required for testing

--- a/scripts/camkes.sh
+++ b/scripts/camkes.sh
@@ -29,6 +29,9 @@ test -d "$DIR" || DIR=$PWD
 # tmp space for building
 : "${TEMP_DIR:=/tmp}"
 
+# Required for cakeml
+/tmp/apply-polyml.sh
+
 # At the end of each Docker image, we switch back to normal Debian
 # apt repos, so we need to switch back to the Snapshot repos now
 possibly_toggle_apt_snapshot
@@ -72,13 +75,6 @@ as_root apt-get install -y --no-install-recommends \
     rsync \
     xxd \
     # end of list
-
-# Required for cakeml
-as_root apt-get install -y --no-install-recommends \
-    polyml \
-    libpolyml-dev \
-    # end of list
-
 
 # Get python deps for CAmkES
 as_root pip3 install --break-system-packages --no-cache-dir \

--- a/scripts/camkes.sh
+++ b/scripts/camkes.sh
@@ -81,7 +81,7 @@ as_root apt-get install -y --no-install-recommends \
 
 
 # Get python deps for CAmkES
-as_root pip3 install --no-cache-dir \
+as_root pip3 install --break-system-packages --no-cache-dir \
     camkes-deps \
     nose \
     # end of list

--- a/scripts/sel4.sh
+++ b/scripts/sel4.sh
@@ -159,9 +159,9 @@ fi
 # Get seL4 python3 deps
 # Pylint is for checking included python scripts
 # Setuptools sometimes is a bit flaky, so double checking it is installed here
-as_root pip3 install --no-cache-dir \
+as_root pip3 install --break-system-packages --no-cache-dir \
     setuptools
-as_root pip3 install --no-cache-dir \
+as_root pip3 install --break-system-packages --no-cache-dir \
     pylint \
     sel4-deps
     # end of list

--- a/scripts/sel4.sh
+++ b/scripts/sel4.sh
@@ -25,9 +25,9 @@ test -d "$DIR" || DIR=$PWD
 # tmp space for building
 : "${TEMP_DIR:=/tmp}"
 
-X64_CROSS="g++-10-aarch64-linux-gnu gcc-10-aarch64-linux-gnu gcc-10-multilib"
-ARM64_CROSS="gcc-10-x86-64-linux-gnu:arm64 g++-10-x86-64-linux-gnu:arm64 \
-             gcc-10-i686-linux-gnu:arm64 g++-10-i686-linux-gnu:arm64"
+X64_CROSS="g++-14-aarch64-linux-gnu gcc-14-aarch64-linux-gnu gcc-14-multilib"
+ARM64_CROSS="gcc-14-x86-64-linux-gnu:arm64 g++-14-x86-64-linux-gnu:arm64 \
+             gcc-14-i686-linux-gnu:arm64 g++-14-i686-linux-gnu:arm64"
 
 # TARGETPLATFORM is set by docker during the build process
 if [ "$TARGETPLATFORM" = "linux/amd64" ]; then
@@ -49,7 +49,7 @@ as_root dpkg --add-architecture armel
 as_root dpkg --add-architecture arm64
 # shellcheck disable=SC2086
 as_root apt-get install -y --no-install-recommends \
-    astyle=3.1-2+b1 \
+    astyle=3.1-3+b3 \
     build-essential \
     ccache \
     cmake \
@@ -71,23 +71,23 @@ as_root apt-get install -y --no-install-recommends \
     qemu-system-x86 \
     sloccount \
     u-boot-tools \
-    clang-11 \
-    g++-10 \
-    g++-10-arm-linux-gnueabi \
-    g++-10-arm-linux-gnueabihf \
-    gcc-10 \
-    gcc-10-arm-linux-gnueabi \
-    gcc-10-arm-linux-gnueabihf \
-    gcc-10-base \
+    clang-19 \
+    g++-14 \
+    g++-14-arm-linux-gnueabi \
+    g++-14-arm-linux-gnueabihf \
+    gcc-14 \
+    gcc-14-arm-linux-gnueabi \
+    gcc-14-arm-linux-gnueabihf \
+    gcc-14-base \
     gcc-riscv64-unknown-elf \
-    libclang-11-dev \
+    libclang-19-dev \
     qemu-system-arm \
     qemu-system-misc \
     $CROSS
     # end of list
 
 if [ "$DESKTOP_MACHINE" = "no" ] ; then
-    compiler_version=10
+    compiler_version=14
 
     # Set default compiler to be gcc-$compiler_version using update-alternatives
     # This is necessary particularly for the cross-compilers, which don't put
@@ -144,12 +144,12 @@ if [ "$DESKTOP_MACHINE" = "no" ] ; then
         done
     done
 
-    # Ensure that clang-11 shows up as clang
+    # Ensure that clang-19 shows up as clang
     for compiler in clang \
                     clang++ \
                     # end of list
         do
-            as_root update-alternatives --install /usr/bin/"$compiler" "$compiler" "$(which "$compiler"-11)" 60 && \
+            as_root update-alternatives --install /usr/bin/"$compiler" "$compiler" "$(which "$compiler"-19)" 60 && \
             as_root update-alternatives --auto "$compiler"
     done
     # Do a quick check to make sure it works:

--- a/scripts/sel4.sh
+++ b/scripts/sel4.sh
@@ -44,8 +44,6 @@ fi
 as_root apt-get update -q
 as_root dpkg --add-architecture amd64
 as_root dpkg --add-architecture i386
-as_root dpkg --add-architecture armhf
-as_root dpkg --add-architecture armel
 as_root dpkg --add-architecture arm64
 # shellcheck disable=SC2086
 as_root apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Currently still in draft for testing.

Update the containers to use Trixie as the base image. This means:

- tool chain upgrades to python-3.13, gcc-14, and clang-19
- minor reorg for new base image changes
- dropping `armel` and `armhf` (see #92)
- account for packages that are no longer available and need to be built from source
- minor docker syntax updates
