### PR TITLE
build.sh: switch to buildx build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -32,7 +32,7 @@ set -ef
 : "${PREBUILT_SYSINIT_IMG:=prebuilt_sysinit}"
 
 # Extra vars
-DOCKER_BUILD="docker build"
+DOCKER_BUILD="docker buildx build --load"
 DOCKER_INSPECT="docker inspect"
 DOCKER_FLAGS="--force-rm=true"
 


### PR DESCRIPTION
docker now produces warnings when building with the old `build` command. It clearly is much more convenient for developers to type `docker buildx build --load` instead.
