### PR TITLE
sel4.sh: additional llvm dependencies

### DIFF
--- a/scripts/sel4.sh
+++ b/scripts/sel4.sh
@@ -69,7 +69,10 @@ as_root apt-get install -y --no-install-recommends \
     qemu-system-x86 \
     sloccount \
     u-boot-tools \
+    llvm-19 \
+    llvm-19-dev \
     clang-19 \
+    libclang-19-dev \
     lld-19 \
     g++-14 \
     g++-14-arm-linux-gnueabi \
@@ -79,7 +82,6 @@ as_root apt-get install -y --no-install-recommends \
     gcc-14-arm-linux-gnueabihf \
     gcc-14-base \
     gcc-riscv64-unknown-elf \
-    libclang-19-dev \
     qemu-system-arm \
     qemu-system-misc \
     $CROSS

--- a/scripts/sel4.sh
+++ b/scripts/sel4.sh
@@ -82,6 +82,7 @@ as_root apt-get install -y --no-install-recommends \
     gcc-14-arm-linux-gnueabihf \
     gcc-14-base \
     gcc-riscv64-unknown-elf \
+    binutils-riscv64-unknown-elf \
     qemu-system-arm \
     qemu-system-misc \
     $CROSS
@@ -145,14 +146,19 @@ if [ "$DESKTOP_MACHINE" = "no" ] ; then
         done
     done
 
-    # Ensure that clang-19 shows up as clang
-    for compiler in clang \
-                    clang++ \
-                    lld \
-                    # end of list
+    # Ensure that clang-19 and the LLVM binutils show up without version suffix.
+    for tool in clang \
+                clang++ \
+                lld \
+                llvm-ar \
+                llvm-nm \
+                llvm-objcopy \
+                llvm-ranlib \
+                llvm-strip \
+                # end of list
         do
-            as_root update-alternatives --install /usr/bin/"$compiler" "$compiler" "$(which "$compiler"-19)" 60 && \
-            as_root update-alternatives --auto "$compiler"
+            as_root update-alternatives --install /usr/bin/"$tool" "$tool" "$(which "$tool"-19)" 60 && \
+            as_root update-alternatives --auto "$tool"
     done
     # Do a quick check to make sure it works:
     clang --version

--- a/scripts/sel4.sh
+++ b/scripts/sel4.sh
@@ -164,6 +164,21 @@ if [ "$DESKTOP_MACHINE" = "no" ] ; then
     clang --version
 fi
 
+# make RISC-V versions of libgcc.a available to clang/lld
+CLANG_RT=/usr/lib/llvm-19/lib/clang-runtimes
+
+# rv64
+RISCV_DIR=riscv64-unknown-elf/rv64imafdc/lp64d/lib
+as_root mkdir -p $CLANG_RT/$RISCV_DIR
+as_root ln -s "$(riscv64-unknown-elf-gcc -march=rv64imafdc -mabi=lp64d -print-libgcc-file-name)" \
+    $CLANG_RT/$RISCV_DIR/libgcc.a
+
+# rv32; libgcc.a expected in riscv64-unknown-elf/lib/
+RISCV_DIR=riscv64-unknown-elf/lib
+as_root mkdir -p $CLANG_RT/$RISCV_DIR
+as_root ln -s "$(riscv64-unknown-elf-gcc -march=rv32imac -mabi=ilp32 -print-libgcc-file-name)" \
+    $CLANG_RT/$RISCV_DIR/libgcc.a
+
 # Get seL4 python3 deps
 # Pylint is for checking included python scripts
 # Setuptools sometimes is a bit flaky, so double checking it is installed here


### PR DESCRIPTION
RISC-V builds for the kernel standalone build were succeeding, but sel4test needs a few more tools that apparently do not get installed via `clang-19` alone. 