### PR TITLE
polyml/cakeml sync

### DIFF
--- a/scripts/apply-polyml.sh
+++ b/scripts/apply-polyml.sh
@@ -9,7 +9,7 @@
 
 set -exuo pipefail
 
-version="5.9.2"
+version="5.7.1"
 url="https://github.com/polyml/polyml/archive/refs/tags/v${version}.tar.gz"
 TMP_DIR="/tmp"
 

--- a/scripts/apply-polyml.sh
+++ b/scripts/apply-polyml.sh
@@ -18,7 +18,11 @@ wget -4 "${url}" --directory-prefix="$TMP_DIR"
 pushd "$TMP_DIR"
 tar -xzf "v${version}.tar.gz"
 pushd "polyml-${version}"
-./configure --prefix=/usr
+# patch polyml-5.7.1 for glibc 2.34+
+sed -i 's|#if (PTHREAD_STACK_MIN < 4096)|#if 0|' libpolyml/sighandler.cpp
+# Force HAVE_ASM_ELF_H to no for polyml-5.7.1; comment says Android only
+# https://github.com/polyml/polyml/blob/v5.7.1/libpolyml/elfexport.cpp#L93-L96
+./configure --prefix=/usr ac_cv_header_asm_elf_h=no
 make
 make install
 rm -rf "v${version}.tar.gz" "polyml-${version}"

--- a/scripts/cakeml.sh
+++ b/scripts/cakeml.sh
@@ -42,7 +42,7 @@ try_nonroot_first git clone https://github.com/HOL-Theorem-Prover/HOL.git "$HOL_
 pushd "$HOL_DIR"
     git checkout $HOL_COMMIT
     mkdir -p tools-poly
-    echo "val polymllibdir =\"/usr/lib/x86_64-linux-gnu/\";" > tools-poly/poly-includes.ML
+    echo "val polymllibdir =\"/usr/lib/\";" > tools-poly/poly-includes.ML
     poly < tools/smart-configure.sml
     bin/build
     chmod -R 757 "$PWD"

--- a/scripts/cakeml.sh
+++ b/scripts/cakeml.sh
@@ -40,7 +40,7 @@ as_root apt-get update -q
 # Set up tools to compile CakeML
 try_nonroot_first git clone https://github.com/HOL-Theorem-Prover/HOL.git "$HOL_DIR" || chown_dir_to_user "$HOL_DIR"
 pushd "$HOL_DIR"
-    git checkout $HOL_COMMIT
+    git checkout "$HOL_COMMIT"
     mkdir -p tools-poly
     echo "val polymllibdir =\"/usr/lib/\";" > tools-poly/poly-includes.ML
     poly < tools/smart-configure.sml
@@ -72,7 +72,7 @@ get_cakeml "$CAKEML64_BIN_DIR" "https://cakeml.org/regression/artefacts/${CAKEML
 if [ "$MAKE_CACHES" = "yes" ] ; then
     try_nonroot_first git clone "$CAKEML_REMOTE" "$CAKEML_DIR" || chown_dir_to_user "$CAKEML_DIR"
     pushd "$CAKEML_DIR"
-        git checkout $CAKEML_COMMIT
+        git checkout "$CAKEML_COMMIT"
         # Pre-build the following cakeml directories to speed up subsequent cakeml app builds
         for dir in "basis" "compiler/parsing";
             do


### PR DESCRIPTION
- cakeml: pin poly to 5.7.1. The pinned cakeml version requires polyml 5.7.1. Updating cakeml is a larger operation (needs updates to corresponding CAmkES apps).
  
  Instead pin the old poly version in the camkes container and update the path where polyml looks for the library file (changed from previous debian package install layout).

- polyml: patch poly 5.7.1 to work with trixie
  poly 5.7.1 is old enough to not work with Debian trixie out of the box:
  - force PTHREAD_STACK_MIN comparison outcome (parameter mismatch on more recent pthreads)
  - ignore Android-only include file (pulled in by `configure` for some reason) that now conflicts with a previous include

This is not exactly nice. If we manage to upgrade CakeML instead so that it works with the current CAmkES examples, that would be better.