### PR TITLE
github: bump GH action versions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -13,7 +13,7 @@ jobs:
     name: Docker images (AMD64)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - run: ./build.sh -v -b sel4
     # the following will also build the plain camkes image:
     - run: ./build.sh -v -b camkes -s cakeml -s rust
@@ -24,7 +24,7 @@ jobs:
     steps:
     - name: "Unlock MacOS Keychain"
       run: security unlock-keychain -p ${{secrets.M2_MINI_PWD}}
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     # don't use cached images on the self-hosted runner to make sure we are
     # picking up current Debian repo state. The GitHub runners start from
     # scratch, so don't need it.
@@ -39,7 +39,7 @@ jobs:
     name: Docker images (l4v)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - run: ./build.sh -v -b sel4
     - run: ./build.sh -v -b camkes
     - run: ./build.sh -v -b l4v

--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -38,7 +38,7 @@ jobs:
     env:
       TAG: ${{ needs.tag.outputs.tag }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: "Build trustworthysystems/sel4"
       run: |
         ./build.sh -v -b sel4
@@ -53,7 +53,7 @@ jobs:
 
     - name: Authenticate
       if: ${{ github.repository_owner == 'seL4' }}
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         username: ${{ secrets.DOCKER_USER }}
         password: ${{ secrets.DOCKER_TOKEN }}
@@ -87,7 +87,7 @@ jobs:
     steps:
     - name: Authenticate
       if: ${{ github.repository_owner == 'seL4' }}
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         username: ${{ secrets.DOCKER_USER }}
         password: ${{ secrets.DOCKER_TOKEN }}
@@ -95,7 +95,7 @@ jobs:
     - name: "Remove old images"
       run: docker system prune -a -f
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: "Build trustworthysystems/sel4"
       run: |
         ./build.sh -vr -b sel4
@@ -135,7 +135,7 @@ jobs:
     env:
       TAG: ${{ needs.tag.outputs.tag }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: "Build trustworthysystems/l4v"
       run: |
@@ -146,7 +146,7 @@ jobs:
 
     - name: Authenticate
       if: ${{ github.repository_owner == 'seL4' }}
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         username: ${{ secrets.DOCKER_USER }}
         password: ${{ secrets.DOCKER_TOKEN }}
@@ -168,7 +168,7 @@ jobs:
     steps:
       - name: Authenticate
         if: ${{ github.repository_owner == 'seL4' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_TOKEN }}
@@ -210,7 +210,7 @@ jobs:
     if: ${{ github.repository_owner == 'seL4' }}
     steps:
       - name: Trigger ci-actions deployment
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.PRIV_REPO_TOKEN }}
           repository: seL4/ci-actions

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # full git history for comparison with other revisions
       - name: Lint Code Base


### PR DESCRIPTION
Node 20 is deprecated. Bump GitHub action dependencies to versions that run on more recent node.